### PR TITLE
[BST-5975] Removing bundler audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
-      - run: bundle exec bundler-audit check --update
   lint:
     strategy:
       matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ group :development do
   # Lock style guide to specific version incase a new version is published with new breaking cops
   gem "boxt_ruby_style_guide", "7.10.0"
   gem "bundler", "~> 2.1"
-  gem "bundler-audit", "~> 0.8"
   gem "byebug", "~> 11.0"
   gem "rake", "~> 13.0"
   gem "rspec", "~> 3.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,12 +8,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.3.2)
-      activesupport (= 6.1.3.2)
-    activerecord (6.1.3.2)
-      activemodel (= 6.1.3.2)
-      activesupport (= 6.1.3.2)
-    activesupport (6.1.3.2)
+    activemodel (6.1.4)
+      activesupport (= 6.1.4)
+    activerecord (6.1.4)
+      activemodel (= 6.1.4)
+      activesupport (= 6.1.4)
+    activesupport (6.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -27,9 +27,6 @@ GEM
       rubocop-rails (= 2.10.1)
       rubocop-rake (= 0.5.1)
       rubocop-rspec (= 2.3.0)
-    bundler-audit (0.8.0)
-      bundler (>= 1.2.0, < 3)
-      thor (~> 1.0)
     byebug (11.1.3)
     concurrent-ruby (1.1.9)
     diff-lcs (1.4.4)
@@ -97,7 +94,6 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
     terminal-notifier (2.0.0)
-    thor (1.1.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
@@ -109,7 +105,6 @@ PLATFORMS
 DEPENDENCIES
   boxt_ruby_style_guide (= 7.10.0)
   bundler (~> 2.1)
-  bundler-audit (~> 0.8)
   byebug (~> 11.0)
   logga!
   rake (~> 13.0)


### PR DESCRIPTION
Removing `bundler-audit` gem as covered by Dependabot and Snyk.